### PR TITLE
Change "People I Follow" to "My Feeds"

### DIFF
--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -113,7 +113,7 @@ class PostsIndex extends React.Component {
         // At homepage (@user/feed) say "People I follow"
         let page_title = 'Posts'; // sensible default here?
         if (typeof this.props.username !== 'undefined' && category === 'feed') {
-            page_title = 'People I follow'; // todo: localization
+            page_title = 'My Feeds'; // todo: localization
         } else {
             switch (topics_order) {
                 case 'trending': // cribbed from Header.jsx where it's repeated 2x already :P


### PR DESCRIPTION
"People I follow" is confusing, and with the sans font it looks like "People l follow". I suggest "My Feeds" instead; the users were already familiar with that more intuitive notion.